### PR TITLE
Add first principle 'work in open' to guides

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -34,6 +34,7 @@ Airbrake
 Errbit
 node-airbrake
 node-hapi-airbrake
+GOV.UK
  - process/new_projects.md
 N.B.
  - README.md
@@ -56,3 +57,6 @@ _to
 _version
 _x-x-x
 x.x.x
+ - applications/software-libraries.md
+package.json
+EnvironmentAgency

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 If you have an idea you'd like to contribute please log an issue.
 
-If you'd like to suggest a change contributions should be submitted via a pull request.
+If you'd like to suggest a change, contributions should be submitted via a pull request.
 
 If you have any questions or need to discuss or check anything contact us via the [#dst-guides](https://defra-digital.slack.com/messages/dst-guides/) channel in [Slack](https://defra-digital.slack.com/).
 
@@ -56,6 +56,6 @@ We don't expect everyone to be available or able to contribute but we want to al
 
 Leave the PR open for at least 3 working days and ensure at least one other person has reviewed it.
 
-Once those who have participated in the PR have said they are happy, first **squash** your commits down to a single commit. Then merge it in GitHub (not locally). Don't forget to also delete the branch in GitHub.
+Once those who have participated in the PR have said they are happy, first **squash** your commits down to a single commit. Then merge it in GitHub (not locally). Don't forget to also delete the branch in GitHub. You can do all this from the GitHub web interface.
 
 Sit back, have a :tropical_drink:, and ponder your next contribution!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DST Guides
 
-[![Build Status](https://travis-ci.org/EnvironmentAgency/dst-guides.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/dst-guides)
+[![Build Status](https://travis-ci.org/DEFRA/dst-guides.svg?branch=master)](https://travis-ci.org/DEFRA/dst-guides)
 
 These guides relate to the work of Digital Service teams in the Environment Agency who are building new [Digital by default](https://www.gov.uk/service-manual/digital-by-default) services.
 
@@ -34,7 +34,7 @@ They cover processes, decisions, how-to's and notes. They are intended to help w
 
 It has been produced as a series of markdown files to make the process of adding and maintaining the documentation as simple as possible. Nothing is fixed and anything documented here is open to change.
 
-It is maintained under source control to cater for this, allowing anyone either within a team to make suggestions for improvement via the standard [pull request process](https://help.github.com/articles/using-pull-requests/).
+It is maintained under source control to cater for this, allowing anyone to make suggestions for improvement via the standard [pull request process](https://help.github.com/articles/using-pull-requests/).
 
 It is pushed to GitHub to make it publicly accessible and to render the content in a presentable format.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ These guides relate to the work of Digital Service teams in the Environment Agen
 - [Applications](/applications)
   - [Error Notifications](/applications/error-notifications.md)
   - [Software Libraries](/applications/software-libraries.md)
+- [Principles](/principles)
+  - [Work in the open](work_in_the_open.md)
 - [Process](/process)
   - [New projects](/process/new_projects.md)
   - [Pull requests](/process/pull_request.md)

--- a/principles/README.md
+++ b/principles/README.md
@@ -1,0 +1,7 @@
+# General Principles
+
+These are general principles on how to develop digital services. They are intended to help you deliver high quality applications that are more secure, easily maintained, and of a high quality.
+
+These principles are stated in no particular order, and are **always** open to change.
+
+- [Work in the open](work_in_the_open.md)

--- a/principles/work_in_the_open.md
+++ b/principles/work_in_the_open.md
@@ -6,9 +6,11 @@
 
 > You must make all new source code open to meet point 8 of the Digital Service Standard.
 
-So you could develop your code in private, and release in time for a [Beta](https://www.gov.uk/service-manual/agile-delivery/how-the-beta-phase-works) assessment, which (other factors aside) would be sufficient to pass.
+So you *could* develop your code in private, and release in time for a [Beta](https://www.gov.uk/service-manual/agile-delivery/how-the-beta-phase-works) assessment, which (other factors aside) would be sufficient to pass.
 
-However we believe there are more benefits to making code public from the beginning, rather than starting private and releasing later.
+However we believe there are more benefits to making code public from the beginning, rather than starting private and releasing later. Here we cover the reasons why, and who has the authority to release your code.
+
+There is also an internal operational instruction for open sourcing code. Contact [Ben Sagar](https://github.com/bensagar-ea) or [Alan Cruikshanks](https://github.com/Cruikshanks) for a copy.
 
 ## Benefits
 
@@ -26,7 +28,7 @@ It's easier to collaborate with colleagues when working on an open repo compared
 
 ### Visibility and sharing
 
-Projects that are open have more visibility which makes it easier for colleagues both In the Environment Agency and in other departments to see what we've built. This encourages collaboration rather than duplication.
+Projects that are open have more visibility which makes it easier for colleagues both in the Environment Agency and in other departments to see what we've built. This encourages collaboration rather than duplication.
 
 It also means the code can benefit more people by being shared. Not only can others use your code they can see which problems you have already solved.
 
@@ -38,12 +40,15 @@ Starting public prevents you from storing up additional work which has to be don
 
 ### Quality
 
-We believe the quality of public projects is better than private ones. Our (unscientific!) opinion is based on the belief that
+We believe the quality of public projects is better than private ones. Our opinion is based on the belief that
 
 - Access to quality metrics means contributors are less likely to commit code without test coverage
 - Documentation is created and updated from the start rather than later, for example when going from private to public
 - Developers make more balanced decisions between delivery and quality due to the possibility of public scrutiny
+- The code is more secure. It encourages a separation of information, forcing contributors to consider what *really* needs to be protected from that which doesn't.
 
 ## Authority to 'go open'
 
-When writing code on a project, authority to release that code falls under the data custodian for the area of the business the service belongs to. Scheduling a meeting with the data custodian should be a priority in sprint 1, so you can get your code open and take advantage of the benefits above as soon as possible.
+When writing code on a project, authority to release that code falls under the data custodian for the area of the business the service belongs to. Making contact and securing this authorisation should be a priority from the start of Alpha.
+
+You should be open by the time of your alpha assessment, as it will ensure you meet [point 8](https://www.gov.uk/service-manual/service-standard/make-all-new-source-code-open) of the standard, and is an Environment Agency pre-condition to the team starting beta.

--- a/principles/work_in_the_open.md
+++ b/principles/work_in_the_open.md
@@ -1,0 +1,49 @@
+# Work in the open
+
+> *Our code is open as early as possible. We only go private if we really, really, **really** have to!*
+
+[Point 8](https://www.gov.uk/service-manual/service-standard/make-all-new-source-code-open) of the [Digital Service Standard](https://www.gov.uk/service-manual/service-standard) states
+
+> You must make all new source code open to meet point 8 of the Digital Service Standard.
+
+So you could develop your code in private, and release in time for a [Beta](https://www.gov.uk/service-manual/agile-delivery/how-the-beta-phase-works) assessment, which (other factors aside) would be sufficient to pass.
+
+However we believe there are more benefits to making code public from the beginning, rather than starting private and releasing later.
+
+## Benefits
+
+### Free stuff
+
+Public repositories benefit from lots of free services. Continuous integration, dependency checking, code quality and test coverage are just a few of the things you can get for free if your project is open.
+
+### You've passed
+
+...point 8 of the Digital service standard (if you're a digital service going on [GOV.UK](https://gov.uk)). No last minute rush to release something just before an assessment, you're sorted from day one.
+
+### Flexibility
+
+It's easier to collaborate with colleagues when working on an open repo compared to a private one. Though you may have to grant access to allow them to make changes, there is nothing stopping them from looking at and referring to the code.
+
+### Visibility and sharing
+
+Projects that are open have more visibility which makes it easier for colleagues both In the Environment Agency and in other departments to see what we've built. This encourages collaboration rather than duplication.
+
+It also means the code can benefit more people by being shared. Not only can others use your code they can see which problems you have already solved.
+
+### No re-work
+
+In our experience all projects that started private with the intention of going public later found that additional work was needed before this could happen. Projects that started public however never seem to experience this overhead.
+
+Starting public prevents you from storing up additional work which has to be done, normally at a time where you're priority is actually to get it live.
+
+### Quality
+
+We believe the quality of public projects is better than private ones. Our (unscientific!) opinion is based on the belief that
+
+- Access to quality metrics means contributors are less likely to commit code without test coverage
+- Documentation is created and updated from the start rather than later, for example when going from private to public
+- Developers make more balanced decisions between delivery and quality due to the possibility of public scrutiny
+
+## Authority to 'go open'
+
+When writing code on a project, authority to release that code falls under the data custodian for the area of the business the service belongs to. Scheduling a meeting with the data custodian should be a priority in sprint 1, so you can get your code open and take advantage of the benefits above as soon as possible.


### PR DESCRIPTION
Having some principles for how to approach work is a common practice amongst dev 'shops'. Their value became clear to me during my time as *Permissions & Compliance Development Manager*. Specifically I was looking to clear up some of the ambiguity around proposals and suggestions being made. Having agreed in *principal* how to go about a thing, we could then get into the detail.

I've so far written up 4 which I'd like to submit, but believe it would be better to tackle them one at a time. **Work in the open** is the first of them. They have been previously passed around the Bristol and Bridgwater teams to get initial feedback, but a mix of time off, work pressures, and general *reasons* has meant they got no further.

I recent cross post to a [blog](https://mojdigital.blog.gov.uk/2016/12/23/a-principled-approach-to-development/) about the [MoJ's Digital Development Principles](https://docs.google.com/document/d/1e-K0apLsBwKWIb5ggPcXTToDinZ7rUVkoto_XBDkyLw/edit#heading=h.x7rqvxvhiwcm) reminded me of them, hence this proposed change to guides.

This change specifically covers

- adding a new principles folder with accompanying README
- adding a new guide title 'Work in the open'
- add a link to the principles README and 'Work in the open' guide to the root README
