### PR TITLE
Add link to supportive blog on coding in the open

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These guides relate to the work of Digital Service teams in the Environment Agen
   - [Error Notifications](/applications/error-notifications.md)
   - [Software Libraries](/applications/software-libraries.md)
 - [Principles](/principles)
-  - [Work in the open](work_in_the_open.md)
+  - [Work in the open](/principles/work_in_the_open.md)
 - [Process](/process)
   - [New projects](/process/new_projects.md)
   - [Pull requests](/process/pull_request.md)

--- a/principles/work_in_the_open.md
+++ b/principles/work_in_the_open.md
@@ -1,6 +1,6 @@
 # Work in the open
 
-> *Our code is open as early as possible. We only go private if we really, really, **really** have to!*
+> _Our code is open as early as possible. We only go private if we really, really, **really** have to!_
 
 [Point 8](https://www.gov.uk/service-manual/service-standard/make-all-new-source-code-open) of the [Digital Service Standard](https://www.gov.uk/service-manual/service-standard) states
 
@@ -8,7 +8,7 @@
 
 So you *could* develop your code in private, and release in time for a [Beta](https://www.gov.uk/service-manual/agile-delivery/how-the-beta-phase-works) assessment, which (other factors aside) would be sufficient to pass.
 
-However we believe there are more benefits to making code public from the beginning, rather than starting private and releasing later. Here we cover the reasons why, and who has the authority to release your code.
+However we believe there are more benefits to making code public from the beginning, rather than starting private and releasing later, and we're not the only ones. For example, see this [blog post by the Ministry of Justice on why they code in the open](https://mojdigital.blog.gov.uk/2017/02/21/why-we-code-in-the-open/). Here we cover the reasons why, and who has the authority to release your code.
 
 There is also an internal operational instruction for open sourcing code. Contact [Ben Sagar](https://github.com/bensagar-ea) or [Alan Cruikshanks](https://github.com/Cruikshanks) for a copy.
 


### PR DESCRIPTION
Recently (at the time of this commit) the Ministry of Justice published a blog post on [Why they code in the open](https://mojdigital.blog.gov.uk/2017/02/21/why-we-code-in-the-open/). This is not just evidence of another department making code open, but believing that writing code in the open makes for **better code**. This is the main argument behind our principle of **Work in the open**.

The blog post also has some great responses for one of the most common arguments against this; Doesn’t it give attackers an advantage? Therefore it was felt advantageous to add a link to it in the [Work in the open](/principles/work_in_the_open.md) guide.

N.B. This also fixes a broken link on the root README page.