### PR TITLE
Add new principle 'Master is always shippable'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ These guides relate to the work of Digital Service teams in the Environment Agen
   - [Error Notifications](/applications/error-notifications.md)
   - [Software Libraries](/applications/software-libraries.md)
 - [Principles](/principles)
+  - [Master is always shippable](/principles/master_is_always_shippable.md)
   - [The code is not yours](/principles/code_is_not_yours.md)
   - [Work in the open](/principles/work_in_the_open.md)
 - [Process](/process)

--- a/principles/README.md
+++ b/principles/README.md
@@ -4,5 +4,6 @@ These are general principles on how to develop digital services. They are intend
 
 These principles are stated in no particular order, and are **always** open to change.
 
+- [Master is always shippable](master_is_always_shippable.md)
 - [The code is not yours](code_is_not_yours.md)
 - [Work in the open](work_in_the_open.md)

--- a/principles/master_is_always_shippable.md
+++ b/principles/master_is_always_shippable.md
@@ -1,0 +1,19 @@
+# Master is always shippable
+
+> *The main branch(s) of a project is always in a state of 'shippable to production'*
+
+All work committed to `master` (and `develop` if using [git flow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)) is considered complete and production ready. It has sufficient tests, matches agreed styles, doesn't break the build, has documentation, and is *our best solution* at the time of committing.
+
+## Nothing is perfect
+
+The main principle is anything we commit to `master` we also would be happy to have in production.
+
+However the principle is not that everything committed to `master` is [perfect](http://www.azquotes.com/quote/1118307). The principle understands that each commit was a team's best endeavours, and these were based on their understanding of the problem, their skills, knowledge, and available resources at the time.
+
+## Branches are 'not' finished
+
+The flip side of this is that branches should always be considered unfinished until the author and team have said they are **ready for review**.
+
+This gives them the space to work through ideas, 'hack' whilst they work through problems, violate styles, good naming etc. Basically get on with developing the feature in the way most comfortable and efficient to them.
+
+Once a branch is **ready for review** though, it should be in a production ready state in order to give any reviewer the best chance of checking the work, and to respect their time.

--- a/process/pull_request.md
+++ b/process/pull_request.md
@@ -11,7 +11,7 @@ We want to respect the time and effort of those reviewing the work. Keeping PR's
 
 ## Always on a branch
 
-No matter how small the change, all changes must be done on a branch and never directly to `master` (or `develop` where [git flow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) is being used).
+No matter how small the change, all changes must be done on a branch and never directly to `master` (or `develop` where [git flow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) is being used). This is to support the principle of [Master is always shippable](../principles/master_is_always_shippable.md)
 
 Clone the repo then create your new branch. Please use one of the following prefixes to help categorise the change being made
 

--- a/process/workflows.md
+++ b/process/workflows.md
@@ -14,7 +14,7 @@ We use Gitflow for anything that is **deployed**. Currently this is the front en
 
 Using this workflow it means our branches have specific uses
 
-- **Master** is the version of code that is in production
+- **Master** is the version of code that is in production (see the principle [Master is always shippable](../principles/master_is_always_shippable.md))
 
 - We create a **Hotfix** branch when we need to make a change to production code because of a critical error. When finished we merge the change back into Master, but also Develop
 


### PR DESCRIPTION
This adds a third proposed principle; that the main branch on any project (typically `master`) is always in a state of ready to ship to production.

The aim is to provide consistency in what to expect when looking at a project; essentially the separation between what a team considers done and what they are still working on. As a potential user, I should always be able to clone or fork a project and know that all tests will pass and that it should run (assuming all dependencies are met) when the main branch is checked out.

One of the inspirations for this was a confrontation with a fellow developer. For 'reasons' I'd taken an interest in another project and began to look at the code and information provided. Seeing possible issues on `master` I made some comments, only for them to be rejected on the basis this was a project in its early stages and still being worked. The team was not seeking outside comments on work that was still incomplete.

My hope is this principle will prevent this type of misunderstanding in the future.