### PR TITLE
Update links to EA org to Defra org

### DIFF
--- a/applications/error-notifications.md
+++ b/applications/error-notifications.md
@@ -21,7 +21,7 @@ For implementations details see  [Node-airbrake](https://github.com/airbrake/nod
 
 ### Hapi based applications
 
-If your application is using [Hapi](http://hapijs.com/) you should use [Node-hapi-airbrake](https://github.com/EnvironmentAgency/node-hapi-airbrake)  instead.
+If your application is using [Hapi](http://hapijs.com/) you should use [Node-hapi-airbrake](https://github.com/DEFRA/node-hapi-airbrake)  instead.
 
 Node-hapi-airbrake is a plug-in wrapper for Node-airbrake, so that it can be loaded as a native plug-in. It also exposes some extra configuration to enable users to connect to hosted Errbit instances, rather than the default Airbrake host.
 
@@ -33,4 +33,4 @@ server.methods.notify(new Error(), (err, url) {
 })
 ```
 
-For implementation details see [Node-hapi-airbrake](https://github.com/EnvironmentAgency/node-hapi-airbrake).
+For implementation details see [Node-hapi-airbrake](https://github.com/DEFRA/node-hapi-airbrake).

--- a/applications/software-libraries.md
+++ b/applications/software-libraries.md
@@ -76,7 +76,7 @@ If in any doubt, consult with your team's senior developer.  If you *are* your t
 
 ## Create organisational GitHub repositories
 
-If your team develops common code that could be reused in a library, or you have an idea for a project that could help in delivering digital services, request a repo under the [EnvironmentAgency](https://github.com/EnvironmentAgency) organisation.
+If your team develops common code that could be reused in a library, or you have an idea for a project that could help in delivering digital services, request a repo under the [Defra](https://github.com/DEFRA) organisation.
 
 **Don't** create personal repositories.
 

--- a/services/frae/README.md
+++ b/services/frae/README.md
@@ -4,9 +4,9 @@ The service comprises these repositories
 
 | Component | Description |
 |:----------|:------------|
-|[Flood risk engine](https://github.com/EnvironmentAgency/flood-risk-engine)| An engine enabling us to share workflows and models across front and back office|
-|[Flood risk back office (private)](https://github.com/EnvironmentAgency/flood-risk-back-office) ||
-|[Flood risk front office](https://github.com/EnvironmentAgency/flood-risk-front-office) | Public facing site - a thin wrapper around the engine|
+|[Flood risk engine](https://github.com/DEFRA/flood-risk-engine)| An engine enabling us to share workflows and models across front and back office|
+|[Flood risk back office (private)](https://github.com/DEFRA/flood-risk-back-office) ||
+|[Flood risk front office](https://github.com/DEFRA/flood-risk-front-office) | Public facing site - a thin wrapper around the engine|
 
 ## Guides
 

--- a/services/frae/solution-release-process.md
+++ b/services/frae/solution-release-process.md
@@ -6,7 +6,7 @@ Exemptions service solution.
 > Please also read the general release guidance and and notes under the
 [Waste Exemptions section]((/services/wex/solution-release-process.md))
 
-## [Flood risk engine](https://github.com/EnvironmentAgency/flood-risk-engine)
+## [Flood risk engine](https://github.com/DEFRA/flood-risk-engine)
 
 > Remember that for gems we use *github flow* rather than gitflow; there is no develop branch, and
 the end result of the release process is a new tagged version.
@@ -36,7 +36,7 @@ tagging the engine it uses so we have a clear understanding of what is being use
 
 - Push tag to GitHub `git push origin vx.x.x`
 
-## [Flood risk front office](https://github.com/EnvironmentAgency/flood-risk-front-office)
+## [Flood risk front office](https://github.com/DEFRA/flood-risk-front-office)
 
 > We use *gitflow* for applications - so work is based off of a develop branch
 
@@ -55,7 +55,7 @@ tagging the engine it uses so we have a clear understanding of what is being use
 
 ```ruby
   gem "flood_risk_engine",
-    git: "https://github.com/EnvironmentAgency/flood-risk-engine",
+    git: "https://github.com/DEFRA/flood-risk-engine",
     tag: "vx.x.x"
 ```
 
@@ -77,7 +77,7 @@ tagging the engine it uses so we have a clear understanding of what is being use
 
 - Push tag to GitHub `git push origin vx.x.x`
 
-## [Flood risk back office](https://github.com/EnvironmentAgency/waste-exemptions-back-office)
+## [Flood risk back office](https://github.com/DEFRA/waste-exemptions-back-office)
 
 Follow the same process as [Flood risk front office](#user-content-flood-risk-front-office) only change
 the initial empty commit message to be

--- a/services/frae/state_engine.md
+++ b/services/frae/state_engine.md
@@ -1,3 +1,3 @@
 # State engine
 
-Please read [this description](https://github.com/EnvironmentAgency/flood-risk-engine/blob/master/app/state_machines/flood_risk_engine/STATE_MACHINE_README.md) of the FRAE state machine implementation.
+Please read [this description](https://github.com/DEFRA/flood-risk-engine/blob/master/app/state_machines/flood_risk_engine/STATE_MACHINE_README.md) of the FRAE state machine implementation.

--- a/services/wex/README.md
+++ b/services/wex/README.md
@@ -8,9 +8,9 @@ To quote the intro on the projects README.
 
 The service itself is built from 3 different repositories
 
-- [Waste exemptions](https://github.com/EnvironmentAgency/waste-exemptions)
-- [Waste exemptions back office](https://github.com/EnvironmentAgency/waste-exemptions-back-office)
-- [Waste exemptions shared](https://github.com/EnvironmentAgency/waste-exemptions-shared)
+- [Waste exemptions](https://github.com/DEFRA/waste-exemptions)
+- [Waste exemptions back office](https://github.com/DEFRA/waste-exemptions-back-office)
+- [Waste exemptions shared](https://github.com/DEFRA/waste-exemptions-shared)
 
 ## Guides
 

--- a/services/wex/solution-release-process.md
+++ b/services/wex/solution-release-process.md
@@ -4,7 +4,7 @@ This details the process of updating each of the projects that make up the Waste
 
 It's focus is the **code**, not the release process itself (i.e. the submission of a *Request for Change*, ensuring deployment is followed by a [smoke test](https://en.wikipedia.org/wiki/Smoke_testing_(software)). The aim is to document that in the guides at a later date.
 
-## [Waste exemptions shared](https://github.com/EnvironmentAgency/waste-exemptions-shared)
+## [Waste exemptions shared](https://github.com/DEFRA/waste-exemptions-shared)
 
 - When ready for release create branch off `master` called *release/x-x-x*.
 
@@ -30,7 +30,7 @@ It's focus is the **code**, not the release process itself (i.e. the submission 
 
 - Push tag to GitHub `git push origin vx.x.x`
 
-## [Waste exemptions](https://github.com/EnvironmentAgency/waste-exemptions)
+## [Waste exemptions](https://github.com/DEFRA/waste-exemptions)
 
 - When ready for release create branch off `develop` called *release/x-x-x*.
 
@@ -47,7 +47,7 @@ It's focus is the **code**, not the release process itself (i.e. the submission 
 ```ruby
 # Core components for WasteExemptions
 gem 'waste_exemptions_shared',
-  git: 'https://github.com/EnvironmentAgency/waste-exemptions-shared',
+  git: 'https://github.com/DEFRA/waste-exemptions-shared',
   tag: 'vx.x.x'
 ```
 
@@ -71,7 +71,7 @@ gem 'waste_exemptions_shared',
 
 - Push tag to GitHub `git push origin vx.x.x`
 
-## [Waste exemptions back office](https://github.com/EnvironmentAgency/waste-exemptions-back-office)
+## [Waste exemptions back office](https://github.com/DEFRA/waste-exemptions-back-office)
 
 Follow the same process as [Waste exemptions](#waste-exemptions) only change the initial empty commit message to be
 


### PR DESCRIPTION
This change both corrects all the links that feature `environmentagency` instead of `defra` in their addresses.

Fixes #44