### PR TITLE
Add details on the Data Returns service to guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ These guides relate to the work of Digital Service teams in the Environment Agen
   - [Register your flood risk activity exemptions](/services/frae)
     - [Solution release process](/services/frae/solution-release-process.md)
     - [State engine](/services/frae/state_engine.md)
+  - [Report landfill data](/services/dr)
   - [Submit your flood or coastal erosion risk management project proposal](/services/pafs)
 - [Style](/style)
   - [JavaScript](/style/javascript.md)

--- a/services/README.md
+++ b/services/README.md
@@ -14,4 +14,6 @@ Provides details and guides specific to a service.
   - [Solution release process](/services/frae/solution-release-process.md)
   - [State engine](/services/frae/state_engine.md)
 
+- [Report landfill data](/services/dr)
+
 - [Submit your flood or coastal erosion risk management project proposal](/services/pafs)

--- a/services/dr/README.md
+++ b/services/dr/README.md
@@ -1,0 +1,28 @@
+# Report landfill data
+
+Also commonly known as the **Data Returns** service, though the team behind it are focused on building a platform rather than a single service, hence the name.
+
+To quote the [guidance page](https://www.gov.uk/guidance/report-landfill-data-england-only)
+
+> Your landfill permit or licence will list the data you must report and when you have to send it.
+>
+> Use this service to report periodic emissions and monitoring data to the Environment Agency.
+
+## High level overview
+
+The service is not a typical transaction based one, with users entering information via a series of ordered steps.
+
+Instead it is designed to allow them to upload data in a CSV, and have the service first validate it, then forward it automatically to a system called EMMA.
+
+The service is made up of an external facing Node.js web app, and a RESTful web service powered by Java [Spring Boot](https://projects.spring.io/spring-boot/). The web service handles the validation of uploaded CSV files.
+
+## Repositories
+
+Currently the service is made up of the following repositories
+
+- [Data returns front end](https://github.com/DEFRA/data-returns-frontend) - external facing Node.js web app
+- [Data returns data exchange](https://github.com/DEFRA/data-returns-data-exchange) - RESTful web service that handles validation of submitted files
+
+The QA and Test engineer manages the following
+
+- [Data returns acceptance tests](https://github.com/DEFRA/data-returns-acceptance-tests) - automated acceptance tests for the service


### PR DESCRIPTION
Data Returns is a service in public beta. This change adds an initial guide to provide basic details on the service. This should act as a base for those working on the service to add more information about it future.

Till then, we acknowledge it's existence in DST-guides with this new guide.