### PR TITLE
Fix code blocks for markdown styling

### DIFF
--- a/style/markdown.md
+++ b/style/markdown.md
@@ -8,7 +8,7 @@ TL;DR Make it nice, but try and be consistent with the guide if you can.
 
 Use *atx* style headers instead of *Setex*, and don't close them.
 
-```
+```markdown
 # Use atx style headers
 
 # Don't close them #
@@ -19,7 +19,7 @@ Don't use Setext style
 
 When inlining a code example just use single backticks.
 
-````
+````markdown
 Do this `generate_foo()`
 Don't do this ```generate_foo()```
 ````
@@ -28,7 +28,7 @@ Use **-** (hyphen) for unordered lists instead of ***** (asterisk).
 
 When leading into a list or code block don't put a period, colon or semi-colon at the end of the leading sentence.
 
-````
+````markdown
 Lead into a code block like this
 
 ```ruby

--- a/style/markdown.md
+++ b/style/markdown.md
@@ -8,33 +8,39 @@ TL;DR Make it nice, but try and be consistent with the guide if you can.
 
 Use *atx* style headers instead of *Setex*, and don't close them.
 
-    # Use atx style headers
+```
+# Use atx style headers
 
-    # Don't close them #
+# Don't close them #
 
-    Don't use Setext style
-    ======================
+Don't use Setext style
+======================
+```
 
 When inlining a code example just use single backticks.
 
-    Do this `generate_foo()`
-    Don't do this ```generate_foo()```
+````
+Do this `generate_foo()`
+Don't do this ```generate_foo()```
+````
 
 Use **-** (hyphen) for unordered lists instead of ***** (asterisk).
 
 When leading into a list or code block don't put a period, colon or semi-colon at the end of the leading sentence.
 
-    Lead into a code block this
+````
+Lead into a code block like this
 
-    ```ruby
-    generate_foo()
-    ```
+```ruby
+generate_foo()
+```
 
-    Not like this:
+Not like this:
 
-    ```ruby
-    generate_foo()
-    ```
+```ruby
+generate_foo()
+```
+````
 
 When mentioning tools or gems, link to them on first reference and then highlight them in *bold*.
 


### PR DESCRIPTION
Our markdown style guide had some markdown style violations, as we were using indentations for nested code blocks. Using four backticks serves the same purpose, hopefully without irritating the linter.