### PR TITLE
Switch accessibility links to QA wiki pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ These guides relate to the work of Digital Service Teams (DST) in the Environmen
   - [New projects](/process/new_projects.md)
 - [Process](/process)
   - [Releases](/process/releases.md)
-  - [Accessibility](https://github.com/DEFRA/qa-test/blob/master/accessibility/accessibility_checklist.md)
+  - [Accessibility](https://github.com/DEFRA/qa-test/wiki/Accessibility)
 - [Services](/services)
   - [Apply for a standard rules waste permit](/services/wp)
   - [Register or renew as a waste carrier, broker or dealer](/services/wcr)

--- a/process/README.md
+++ b/process/README.md
@@ -3,4 +3,4 @@
 Guides covering how we do things
 
 - [Releases](releases.md)
-- [Accessibility](https://github.com/DEFRA/qa-test/blob/master/accessibility/accessibility_checklist.md)
+- [Accessibility](https://github.com/DEFRA/qa-test/wiki/Accessibility)

--- a/process/accessibility.md
+++ b/process/accessibility.md
@@ -2,4 +2,4 @@
 
 Our accessibility guidance has moved to the quality assurance and test pages:
 
-https://github.com/DEFRA/qa-test/tree/master/accessibility
+https://github.com/DEFRA/qa-test/wiki/Accessibility

--- a/process/accessibility_checklist.md
+++ b/process/accessibility_checklist.md
@@ -2,4 +2,4 @@
 
 Our accessibility checklist has moved to the quality assurance and test pages:
 
-https://github.com/DEFRA/qa-test/blob/master/accessibility/accessibility_checklist.md
+https://github.com/DEFRA/qa-test/wiki/Accessibility-checklist


### PR DESCRIPTION
As the QA pages currently use wiki format, this change reflects that move.